### PR TITLE
Add Service entities and Rename processUsers to synchronizers

### DIFF
--- a/docs/jupiterone-io/jupiter-integration-okta.md
+++ b/docs/jupiterone-io/jupiter-integration-okta.md
@@ -19,14 +19,20 @@ Instructions on creating an API token within your Okta account can be found
 
 The following entity resources are ingested when the integration runs:
 
-| Okta Entity Resource | \_type : \_class of the Entity      |
-| -------------------- | ----------------------------------- |
-| Account              | `okta_account` : `Account`          |
-| Application          | `okta_application` : `Application`  |
-| Application Group    | `okta_app_user_group` : `UserGroup` |
-| MFA Factor           | `mfa_device` : `[Key,AccessKey]`    |
-| Okta Group           | `okta_user_group` : `UserGroup`     |
-| User                 | `okta_user` : `User`                |
+| Okta Entity Resource  | \_type : \_class of the Entity        |
+| --------------------- | ------------------------------------- |
+| Account               | `okta_account` : `Account`            |
+| Service (SSO & MFA)\* | `okta_service` : `Service`, `Control` |
+| Application           | `okta_application` : `Application`    |
+| Application Group     | `okta_app_user_group` : `UserGroup`   |
+| MFA Factor            | `mfa_device` : `[Key,AccessKey]`      |
+| Okta Group            | `okta_user_group` : `UserGroup`       |
+| User                  | `okta_user` : `User`                  |
+
+_Note: the `Service` entities can later be connected to security policy
+procedures as control providers. This mapping establishes evidence that your
+organization security policies, procedures and controls are fully implemented,
+monitored, and managed._
 
 ## Relationships
 
@@ -35,6 +41,7 @@ The following relationships are created/mapped:
 |                                                   |
 | ------------------------------------------------- |
 | `okta_account` **HAS** `okta_application`         |
+| `okta_account` **HAS** `okta_service`             |
 | `okta_account` **HAS** `okta_user_group`          |
 | `okta_user` **ASSIGNED** `okta_application`       |
 | `okta_user` **ASSIGNED** `mfa_device`             |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/jupiter-integration-okta",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "A JupiterOne managed integration for https://www.okta.com",
   "main": "index.js",
   "repository": "https://github.com/jupiterone/jupiter-integration-okta",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,9 +4,12 @@ export const ENTITY_TYPE_APP_USER_GROUP = "okta_app_user_group";
 export const ENTITY_TYPE_APPLICATION = "okta_application";
 export const ENTITY_TYPE_ACCOUNT = "okta_account";
 export const ENTITY_CLASS_ACCOUNT = "Account";
+export const ENTITY_TYPE_SERVICE = "okta_service";
+export const ENTITY_CLASS_SERVICE = ["Service", "Control"];
 export const ENTITY_TYPE_FACTOR = "mfa_device";
 export const RELATIONSHIP_TYPE_USER_FACTOR = "okta_user_assigned_factor";
 export const RELATIONSHIP_TYPE_GROUP_USER = "okta_group_has_user";
+export const RELATIONSHIP_TYPE_ACCOUNT_SERVICE = "okta_account_has_service";
 export const RELATIONSHIP_TYPE_ACCOUNT_GROUP = "okta_account_has_group";
 export const RELATIONSHIP_TYPE_ACCOUNT_APPLICATION =
   "okta_account_has_application";

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -1,4 +1,12 @@
 import * as url from "url";
+
+import {
+  EntityFromIntegration,
+  RelationshipDirection,
+  RelationshipFromIntegration,
+} from "@jupiterone/jupiter-managed-integration-sdk";
+
+import * as constants from "./constants";
 import {
   FlattenedOktaUser,
   FlattenedOktaUserGroup,
@@ -20,13 +28,6 @@ import {
   StandardizedOktaUserGroup,
   StandardizedOktaUserGroupRelationship,
 } from "./types";
-
-import {
-  RelationshipDirection,
-  RelationshipFromIntegration,
-} from "@jupiterone/jupiter-managed-integration-sdk";
-
-import * as constants from "./constants";
 import buildAppShortName from "./util/buildAppShortName";
 import getOktaAccountAdminUrl from "./util/getOktaAccountAdminUrl";
 import getOktaAccountInfo from "./util/getOktaAccountInfo";
@@ -212,6 +213,45 @@ export function convertOktaUserGroup(
   };
 
   return entity;
+}
+
+export function createHasRelationships(
+  fromEntity: EntityFromIntegration,
+  toEntities: EntityFromIntegration[],
+  relationshipType: string,
+  relationshipProperties?: any,
+) {
+  const relationships: RelationshipFromIntegration[] = [];
+  for (const e of toEntities) {
+    relationships.push(
+      createHasRelationship(
+        fromEntity,
+        e,
+        relationshipType,
+        relationshipProperties,
+      ),
+    );
+  }
+  return relationships;
+}
+
+export function createHasRelationship(
+  fromEntity: EntityFromIntegration,
+  toEntity: EntityFromIntegration,
+  relationshipType: string,
+  relationshipProperties?: any,
+) {
+  const relationship: RelationshipFromIntegration = {
+    _key: `${fromEntity._key}|has|${toEntity._key}`,
+    _type: relationshipType,
+    _class: "HAS",
+    _fromEntityKey: fromEntity._key,
+    _toEntityKey: toEntity._key,
+    displayName: "HAS",
+    ...relationshipProperties,
+  };
+
+  return relationship;
 }
 
 export function convertOktaUserGroupRelationship(

--- a/src/executionHandler.ts
+++ b/src/executionHandler.ts
@@ -4,13 +4,13 @@ import {
   IntegrationInvocationEvent,
 } from "@jupiterone/jupiter-managed-integration-sdk";
 import initializeContext from "./initializeContext";
-import processUsers from "./processUsers";
+import synchronize from "./synchronizer";
 
 export default async function executionHandler(
   context: IntegrationExecutionContext<IntegrationInvocationEvent>,
 ): Promise<IntegrationExecutionResult> {
   const executionContext = await initializeContext(context);
-  const operations = await processUsers(executionContext);
+  const operations = await synchronize(executionContext);
   return {
     operations: await executionContext.persister.publishPersisterOperations(
       operations,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -260,6 +260,13 @@ export interface StandardizedOktaAccount extends EntityFromIntegration {
   webLink: string;
 }
 
+export interface StandardizedOktaService extends EntityFromIntegration {
+  name: string;
+  category: string;
+  function: string;
+  controlDomain: string;
+}
+
 export interface StandardizedOktaAccountGroupRelationship
   extends RelationshipFromIntegration {
   accountUrl: string;


### PR DESCRIPTION
The Service entities will allow users to map policy procedures to them as the controls that implement certain procedures. 