### PR TITLE
Update jupiter-integration-sdk@24.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,10 @@
     "test": "jest"
   },
   "dependencies": {
+    "@jupiterone/jupiter-managed-integration-sdk": "^24.0.2",
     "@okta/okta-sdk-nodejs": "^2.0.0",
     "lodash.startcase": "^4.4.0",
     "promise-retry": "^1.1.1"
-  },
-  "peerDependencies": {
-    "@jupiterone/jupiter-managed-integration-sdk": "^23.2.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
@@ -42,7 +40,6 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-typescript": "^7.1.0",
-    "@jupiterone/jupiter-managed-integration-sdk": "^24.0.1",
     "@types/bunyan": "^1.8.5",
     "@types/fs-extra": "^7.0.0",
     "@types/jest": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/jupiter-integration-okta",
-  "version": "1.3.1",
+  "version": "1.3.2-beta.1",
   "description": "A JupiterOne managed integration for https://www.okta.com",
   "main": "dist/index.js",
   "repository": "https://github.com/jupiterone/jupiter-integration-okta",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,19 @@ import synchronizeGroups from "./synchronizers/synchronizeGroups";
 import synchronizeUsers from "./synchronizers/synchronizeUsers";
 
 const invocationConfig: IntegrationInvocationConfig = {
+  instanceConfigFields: {
+    oktaOrgUrl: {
+      type: "string",
+      mask: false,
+    },
+    oktaApiKey: {
+      type: "string",
+      mask: true,
+    },
+  },
+
   invocationValidator,
+
   integrationStepPhases: [
     {
       steps: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -839,10 +839,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
-"@jupiterone/jupiter-managed-integration-sdk@^24.0.1":
-  version "24.0.1"
-  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-24.0.1.tgz#c1a0d42d16ebdb42f5b08043f057e471637c7667"
-  integrity sha512-xZHjFHlzSKjb2Uxz9dTmaL0IT0PBHPMZkZ1gsuq3vGwM15EXohxN3cDuQ6benaFksi3cQXoncSwy9wr/jdDzMA==
+"@jupiterone/jupiter-managed-integration-sdk@^24.0.2":
+  version "24.0.2"
+  resolved "https://registry.yarnpkg.com/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-24.0.2.tgz#e289906ad83f70fdef24e5216d6d5d11e43a7d6c"
+  integrity sha512-Ckhr8u7aO/Zx6mhdE5z82psjny5r8sGq+Wi/iyAk9GgrUqcOopoLaD3jrVNhsOJxoQZsAP0MS5YJYlQ3TbSVRQ==
 
 "@okta/okta-sdk-nodejs@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
Updates to latest SDK to add support for logging non-sensitive config values to help with debugging.

Note that this places the package into `dependencies` and removes it from elsewhere so that it is transitive to the deployment projects, which will move to stop including the dependency directly, in order that there will be a single version of the SDK in the deployed project and Renovate will stop updating it in the deployed projects without also getting an update of the integration code.